### PR TITLE
[QP-1968] Support QpPause get and update response on post step

### DIFF
--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -885,20 +885,20 @@ function write(
 
   const originalCallback = operationDescription.cb;
 
-  pause.waitOnProtocol(id, 'pre', command, options, errPre => {
+  pause.waitOnProtocol(id, 'pre', command, options, undefined, errPre => {
     if (errPre) {
       originalCallback(errPre);
       return;
     }
 
     const newCallback: Callback<Document> = (err, result) => {
-      pause.waitOnProtocol(id, 'post', command, options, errPost => {
+      pause.waitOnProtocol(id, 'post', command, options, result, (errPost, updatedResult) => {
         if (errPost) {
           originalCallback(errPost);
           return;
         }
 
-        originalCallback(err, result);
+        originalCallback(err, updatedResult);
       });
     };
 

--- a/src/querypie/null-session-pause.ts
+++ b/src/querypie/null-session-pause.ts
@@ -25,45 +25,46 @@ export class QpNullSessionPause extends QpSessionPause {
     phase: QpPausePhase,
     command: WriteProtocolMessageType,
     commandOptions: { [key: string]: any },
-    callback: (err?: any) => void
+    result: Document | undefined,
+    callback: (err: any | undefined, result: Document | undefined) => void
   ) {
     if (commandOptions[QpPause.kNoPause]) {
-      callback();
+      callback(undefined, result);
       return;
     }
 
     if (!QpPause.instance.isCommandCapturing) {
-      callback();
+      callback(undefined, result);
       return;
     }
 
     // Case GetMore
     if ('cursorId' in command) {
       this.log('<QueryPie Warning>', 'GetMore CALLED', command.ns, command.cursorId);
-      callback();
+      callback(undefined, result);
       return;
     }
 
     // Case KillCursor
     if ('cursorIds' in command) {
       this.log('<QueryPie Warning>', 'KillCursor CALLED', command.ns, command.cursorIds);
-      callback();
+      callback(undefined, result);
       return;
     }
 
     if ('query' in command) {
       if (isQueryIgnorable(command)) {
-        callback();
+        callback(undefined, result);
         return;
       }
 
       this.log('<QueryPie Warning>', 'Query CALLED', command.ns, command.query);
-      callback();
+      callback(undefined, result);
       return;
     }
 
     if (isCommandIgnorableInEmptyBus(command.command)) {
-      callback();
+      callback(undefined, result);
       return;
     }
 
@@ -78,6 +79,7 @@ export class QpNullSessionPause extends QpSessionPause {
     phase: QpPausePhase,
     command: Document,
     commandOptions: { [key: string]: any },
+    result: Document | undefined,
     callback: (err?: any) => void
   ) {
     if (commandOptions[QpPause.kNoPause]) {

--- a/src/querypie/session-pause-manager.ts
+++ b/src/querypie/session-pause-manager.ts
@@ -12,7 +12,7 @@ export class QpSessionPauseManager {
     sessionId: string | ClientSession | ServerSessionId | undefined
   ): QpSessionPause {
     const pause = QpSessionPause.createOrGet(sessionId);
-    if (pause === null) {
+    if (pause == null) {
       return this.null;
     }
 


### PR DESCRIPTION
QpPause를 통해서 runCommand의 Post 단계에서 runCommand의 결과를 조회하고, 조작 할 수 있도록 변경하였습니다.