### PR TITLE
[QP-2079] Add missing error callback

### DIFF
--- a/src/cmap/connection.ts
+++ b/src/cmap/connection.ts
@@ -892,6 +892,11 @@ function write(
     }
 
     const newCallback: Callback<Document> = (err, result) => {
+      if (err) {
+        originalCallback(err);
+        return;
+      }
+
       pause.waitOnProtocol(id, 'post', command, options, result, (errPost, updatedResult) => {
         if (errPost) {
           originalCallback(errPost);


### PR DESCRIPTION
### Summary
RunCommand 실행에서 오류가 발생한 경우 Post RunCommand가 불리지 않도록 수정하였습니다.

### Issue
https://chequer.atlassian.net/browse/QP-2079